### PR TITLE
Add utilities for families, persons and insurance metamodel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ tmp/
 # EMF
 src-gen/
 
+#Xtend
+xtend-gen/
+
 # Maven
 target/
 .polyglot.build.properties

--- a/bundles/edu.kit.ipd.sdq.metamodels.families/.classpath
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families/.classpath
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="xtend-gen"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="module" value="true"/>

--- a/bundles/edu.kit.ipd.sdq.metamodels.families/.project
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
@@ -25,5 +30,6 @@
 		<nature>org.eclipse.sirius.nature.modelingproject</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/bundles/edu.kit.ipd.sdq.metamodels.families/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families/META-INF/MANIFEST.MF
@@ -11,6 +11,11 @@ Export-Package: edu.kit.ipd.sdq.metamodels.families,
  edu.kit.ipd.sdq.metamodels.families.impl,
  edu.kit.ipd.sdq.metamodels.families.util
 Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.emf.ecore;visibility:=reexport
+ org.eclipse.emf.ecore;visibility:=reexport,
+ edu.kit.ipd.sdq.activextendannotations,
+ com.google.guava,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtend.lib,
+ org.eclipse.xtend.lib.macro
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: edu.kit.ipd.sdq.metamodels.families

--- a/bundles/edu.kit.ipd.sdq.metamodels.families/build.properties
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families/build.properties
@@ -6,5 +6,7 @@ bin.includes = .,\
                plugin.xml,\
                plugin.properties
 jars.compile.order = .
-source.. = src-gen/
+source.. = src-gen/,\
+           src/,\
+           xtend-gen/
 output.. = target/classes/

--- a/bundles/edu.kit.ipd.sdq.metamodels.families/src/edu/kit/ipd/sdq/metamodels/families/FamiliesUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families/src/edu/kit/ipd/sdq/metamodels/families/FamiliesUtil.xtend
@@ -1,0 +1,72 @@
+package edu.kit.ipd.sdq.metamodels.families
+
+import edu.kit.ipd.sdq.activextendannotations.Utility
+import java.util.ArrayList
+
+@Utility
+class FamiliesUtil {
+	/**
+	 * Returns whether the member is a child in its family.
+	 * 
+	 * @param member the family member, must not be <code>null</code>
+	 */
+	def static boolean isChild(Member member) {
+		return (member.familySon ?: member.familyDaughter) !== null
+	}
+
+	/**
+	 * Returns the family of a members. Returns <code>null</code> if it has no family.
+	 * 
+	 * @param member the member to return the family for, must not be <code>null</code>
+	 */
+	def static Family getFamily(Member member) {
+		return member.familyFather ?: member.familyMother ?: member.familySon ?: member.familyDaughter
+	}
+
+	/**
+	 * Returns the members of a family, consisting of father, mother, sons and daughters.
+	 * 
+	 * @param family the family to return the members for, must not be <code>null</code>
+	 */
+	def static Iterable<Member> getMembers(Family family) {
+		val members = new ArrayList<Member>
+		if (family.father !== null) {
+			members += family.father
+		}
+		if (family.mother !== null) {
+			members += family.mother
+		}
+		members += family.sons
+		members += family.daughters
+		return members
+	}
+
+	/**
+	 * Returns the register of the family of a member.
+	 * 
+	 * @param member the member to return the containing register for, must not be <code>null</code> and must
+	 * 				have a containing family
+	 * @see #getFamily(Member)
+	 * @see #getRegister(Family)
+	 */
+	def static FamilyRegister getRegister(Member member) {
+		return member.family.register
+	}
+
+	/** Returns the eContainer of a Family casted as FamilyRegister, if it is contained in a FamilyRegister.
+	 * 
+	 *  @param family the family to obtain the FamilyRegister from, must not be <code>null</code>
+	 *  @return <code>family.eContainer</code> as FamilyRegister, if it actually is one
+	 *  @throws UnsupportedOperationException if <code>family.eContainer</code> is not a FamilyRegister 
+	 *  to indicate that the case of eContainers of other types is case is not implemented / supported yet.  
+	 */
+	def static FamilyRegister getRegister(Family family) {
+		if (family.eContainer instanceof FamilyRegister) {
+			return family.eContainer as FamilyRegister
+		} else {
+			throw new UnsupportedOperationException(
+				"Cannot retrieve register of a family if it is not its direct container")
+		}
+	}
+
+}

--- a/bundles/edu.kit.ipd.sdq.metamodels.families/src/edu/kit/ipd/sdq/metamodels/families/FamiliesUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families/src/edu/kit/ipd/sdq/metamodels/families/FamiliesUtil.xtend
@@ -53,16 +53,16 @@ class FamiliesUtil {
 		return member.family.register
 	}
 
-	/** Returns the eContainer of a Family casted as FamilyRegister, if it is contained in a FamilyRegister.
+	/** Returns the {@linkplain FamilyRegister} in which the family is contained.
 	 * 
 	 *  @param family the family to obtain the FamilyRegister from, must not be <code>null</code>
-	 *  @return <code>family.eContainer</code> as FamilyRegister, if it actually is one
-	 *  @throws UnsupportedOperationException if <code>family.eContainer</code> is not a FamilyRegister 
-	 *  to indicate that the case of eContainers of other types is case is not implemented / supported yet.  
+	 *  @return <code>family.eContainer</code> as {@linkplain FamilyRegister}, if it actually is one
+	 *  @throws UnsupportedOperationException if the container is not a {@linkplain FamilyRegister}  
 	 */
 	def static FamilyRegister getRegister(Family family) {
-		if (family.eContainer instanceof FamilyRegister) {
-			return family.eContainer as FamilyRegister
+		val container = family.eContainer
+		if (container instanceof FamilyRegister) {
+			return container
 		} else {
 			throw new UnsupportedOperationException(
 				"Cannot retrieve register of a family if it is not its direct container")

--- a/bundles/edu.kit.ipd.sdq.metamodels.insurance/.classpath
+++ b/bundles/edu.kit.ipd.sdq.metamodels.insurance/.classpath
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="xtend-gen"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="module" value="true"/>

--- a/bundles/edu.kit.ipd.sdq.metamodels.insurance/.project
+++ b/bundles/edu.kit.ipd.sdq.metamodels.insurance/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
@@ -25,5 +30,6 @@
 		<nature>org.eclipse.sirius.nature.modelingproject</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/bundles/edu.kit.ipd.sdq.metamodels.insurance/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.insurance/META-INF/MANIFEST.MF
@@ -12,5 +12,10 @@ Export-Package: edu.kit.ipd.sdq.metamodels.insurance,
  edu.kit.ipd.sdq.metamodels.insurance.impl,
  edu.kit.ipd.sdq.metamodels.insurance.util
 Require-Bundle: org.eclipse.emf.ecore;visibility:=reexport,
- org.eclipse.core.runtime
+ org.eclipse.core.runtime,
+ edu.kit.ipd.sdq.activextendannotations,
+ com.google.guava,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtend.lib,
+ org.eclipse.xtend.lib.macro
 Bundle-ActivationPolicy: lazy

--- a/bundles/edu.kit.ipd.sdq.metamodels.insurance/build.properties
+++ b/bundles/edu.kit.ipd.sdq.metamodels.insurance/build.properties
@@ -6,5 +6,7 @@ bin.includes = .,\
                plugin.xml,\
                plugin.properties
 jars.compile.order = .
-source.. = src-gen/
+source.. = src-gen/,\
+           src/,\
+           xtend-gen/
 output.. = target/classes/

--- a/bundles/edu.kit.ipd.sdq.metamodels.insurance/src/edu/kit/ipd/sdq/metamodels/insurance/InsuranceUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.metamodels.insurance/src/edu/kit/ipd/sdq/metamodels/insurance/InsuranceUtil.xtend
@@ -1,0 +1,23 @@
+package edu.kit.ipd.sdq.metamodels.insurance
+
+import edu.kit.ipd.sdq.activextendannotations.Utility
+
+@Utility
+class InsuranceUtil {
+	/** Returns the {@linkplain InsuranceDatabase} in which the client is contained.
+	 * 
+	 *  @param client the client to obtain the {@linkplain InsuranceDatabase} from, must not be <code>null</code>
+	 *  @return <code>client.eContainer</code> as InsuranceDatabase, if it actually is one
+	 *  @throws UnsupportedOperationException if the container is not a {@linkplain InsuranceDatabase}  
+	 */
+	def static InsuranceDatabase getInsuranceDatabase(InsuranceClient client) {
+		val container = client.eContainer
+
+		if (container instanceof InsuranceDatabase) {
+			return container
+		}
+		throw new UnsupportedOperationException(
+			"Cannot retrieve database of an insurance client if it is not its direct container")
+	}
+
+}

--- a/bundles/edu.kit.ipd.sdq.metamodels.persons/.classpath
+++ b/bundles/edu.kit.ipd.sdq.metamodels.persons/.classpath
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="xtend-gen"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="module" value="true"/>

--- a/bundles/edu.kit.ipd.sdq.metamodels.persons/.project
+++ b/bundles/edu.kit.ipd.sdq.metamodels.persons/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
@@ -25,5 +30,6 @@
 		<nature>org.eclipse.sirius.nature.modelingproject</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/bundles/edu.kit.ipd.sdq.metamodels.persons/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.persons/META-INF/MANIFEST.MF
@@ -11,6 +11,11 @@ Export-Package: edu.kit.ipd.sdq.metamodels.persons,
  edu.kit.ipd.sdq.metamodels.persons.impl,
  edu.kit.ipd.sdq.metamodels.persons.util
 Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.emf.ecore;visibility:=reexport
+ org.eclipse.emf.ecore;visibility:=reexport,
+ edu.kit.ipd.sdq.activextendannotations,
+ com.google.guava,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtend.lib,
+ org.eclipse.xtend.lib.macro
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: edu.kit.ipd.sdq.metamodels.persons

--- a/bundles/edu.kit.ipd.sdq.metamodels.persons/build.properties
+++ b/bundles/edu.kit.ipd.sdq.metamodels.persons/build.properties
@@ -6,5 +6,7 @@ bin.includes = .,\
                plugin.xml,\
                plugin.properties
 jars.compile.order = .
-source.. = src-gen/
+source.. = src-gen/,\
+           src/,\
+           xtend-gen/
 output.. = target/classes/

--- a/bundles/edu.kit.ipd.sdq.metamodels.persons/src/edu/kit/ipd/sdq/metamodels/persons/PersonsUtil.xtend
+++ b/bundles/edu.kit.ipd.sdq.metamodels.persons/src/edu/kit/ipd/sdq/metamodels/persons/PersonsUtil.xtend
@@ -1,0 +1,23 @@
+package edu.kit.ipd.sdq.metamodels.persons
+
+import edu.kit.ipd.sdq.activextendannotations.Utility
+
+@Utility
+class PersonsUtil {
+	/** Returns the {@linkplain PersonRegister} in which the person is contained.
+	 * 
+	 *  @param person the person to obtain the {@linkplain PersonRegister} from, must not be <code>null</code>
+	 *  @return <code>person.eContainer</code> as PersonRegister, if it actually is one
+	 *  @throws UnsupportedOperationException if the container is not a {@linkplain PersonRegister}  
+	 */
+	def static PersonRegister getPersonRegister(Person person) {
+		val container = person.eContainer
+
+		if (container instanceof PersonRegister) {
+			return container
+		}
+		throw new UnsupportedOperationException(
+			"Cannot retrieve register of a person if it is not its direct container")
+	}
+
+}

--- a/releng/edu.kit.ipd.sdq.metamodels.demo.parent/pom.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.demo.parent/pom.xml
@@ -23,6 +23,11 @@
 			<layout>p2</layout>
 			<url>http://download.eclipse.org/releases/2021-12</url>
 		</repository>
+		<repository>
+			<id>XAnnotations</id>
+			<layout>p2</layout>
+			<url>https://kit-sdq.github.io/updatesite/release/xannotations/1.5.0/</url>
+		</repository>
 	</repositories>
 
 	<build>


### PR DESCRIPTION
This PR adds utility functions for accessing instances of the families, persons and insurance metamodels, which have previously been defined in [domains of the Vitruv project](https://github.com/vitruv-tools/Vitruv/blob/f4adbe1786f04026c8ac5a80e43f5127cfe8eb05/bundles/domains/tools.vitruv.domains.demo/src/tools/vitruv/domains/demo/families/FamiliesUtil.xtend).