### PR TITLE
Release 1.6.0

### DIFF
--- a/bundles/edu.kit.ipd.sdq.metamodels.addresses.edit/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.addresses.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.addresses.edit;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.addresses.provider.AddressesEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.addresses.edit/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.addresses.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.addresses.edit;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.addresses.provider.AddressesEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.addresses.editor/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.addresses.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.addresses.editor;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.addresses.presentation.AddressesEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.addresses.editor/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.addresses.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.addresses.editor;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.addresses.presentation.AddressesEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.addresses/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.addresses/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.addresses;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/edu.kit.ipd.sdq.metamodels.addresses/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.addresses/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.addresses;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/edu.kit.ipd.sdq.metamodels.families.edit/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.families.edit;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.families.provider.FamiliesEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.families.edit/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.families.edit;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.families.provider.FamiliesEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.families.editor/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.families.editor;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.families.presentation.FamiliesEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.families.editor/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.families.editor;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.families.presentation.FamiliesEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.families/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.families;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/edu.kit.ipd.sdq.metamodels.families/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.families/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.families;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/edu.kit.ipd.sdq.metamodels.insurance.edit/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.insurance.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.insurance.edit;singleton:=true
 Automatic-Module-Name: edu.kit.ipd.sdq.metamodels.insurance.edit
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.insurance.provider.InsuranceEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.insurance.edit/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.insurance.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.insurance.edit;singleton:=true
 Automatic-Module-Name: edu.kit.ipd.sdq.metamodels.insurance.edit
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.insurance.provider.InsuranceEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.insurance.editor/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.insurance.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.insurance.editor;singleton:=true
 Automatic-Module-Name: edu.kit.ipd.sdq.metamodels.insurance.editor
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.insurance.presentation.InsuranceEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.insurance.editor/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.insurance.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.insurance.editor;singleton:=true
 Automatic-Module-Name: edu.kit.ipd.sdq.metamodels.insurance.editor
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.insurance.presentation.InsuranceEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.insurance/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.insurance/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.insurance;singleton:=true
 Automatic-Module-Name: edu.kit.ipd.sdq.metamodels.insurance
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/edu.kit.ipd.sdq.metamodels.insurance/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.insurance/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.insurance;singleton:=true
 Automatic-Module-Name: edu.kit.ipd.sdq.metamodels.insurance
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/edu.kit.ipd.sdq.metamodels.persons.edit/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.persons.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.persons.edit;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.persons.provider.PersonsEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.persons.edit/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.persons.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.persons.edit;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.persons.provider.PersonsEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.persons.editor/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.persons.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.persons.editor;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.persons.presentation.PersonsEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.persons.editor/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.persons.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.persons.editor;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.persons.presentation.PersonsEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.persons/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.persons/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.persons;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/edu.kit.ipd.sdq.metamodels.persons/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.persons/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.persons;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/edu.kit.ipd.sdq.metamodels.recipients.edit/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.recipients.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.recipients.edit;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.recipients.provider.RecipientsEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.recipients.edit/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.recipients.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.recipients.edit;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.recipients.provider.RecipientsEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.recipients.editor/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.recipients.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.recipients.editor;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.recipients.presentation.RecipientsEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.recipients.editor/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.recipients.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.recipients.editor;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: edu.kit.ipd.sdq.metamodels.recipients.presentation.RecipientsEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/bundles/edu.kit.ipd.sdq.metamodels.recipients/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.recipients/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.recipients;singleton:=true
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/edu.kit.ipd.sdq.metamodels.recipients/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.recipients/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.recipients;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/features/edu.kit.ipd.sdq.metamodels.addresses.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.metamodels.addresses.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.metamodels.addresses.feature"
       label="%featureName"
-      version="1.6.0.qualifier"
+      version="1.6.0"
       provider-name="%providerName" >
 
    <description>

--- a/features/edu.kit.ipd.sdq.metamodels.addresses.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.metamodels.addresses.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.metamodels.addresses.feature"
       label="%featureName"
-      version="1.6.0"
+      version="1.7.0.qualifier"
       provider-name="%providerName" >
 
    <description>

--- a/features/edu.kit.ipd.sdq.metamodels.families.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.metamodels.families.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.metamodels.families.feature"
       label="%featureName"
-      version="1.6.0"
+      version="1.7.0.qualifier"
       provider-name="%providerName" >
 
    <description>

--- a/features/edu.kit.ipd.sdq.metamodels.families.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.metamodels.families.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.metamodels.families.feature"
       label="%featureName"
-      version="1.6.0.qualifier"
+      version="1.6.0"
       provider-name="%providerName" >
 
    <description>

--- a/features/edu.kit.ipd.sdq.metamodels.insurance.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.metamodels.insurance.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.metamodels.insurance.feature"
       label="%featureName"
-      version="1.6.0"
+      version="1.7.0.qualifier"
       provider-name="%providerName" >
 
    <description>

--- a/features/edu.kit.ipd.sdq.metamodels.insurance.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.metamodels.insurance.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.metamodels.insurance.feature"
       label="%featureName"
-      version="1.6.0.qualifier"
+      version="1.6.0"
       provider-name="%providerName" >
 
    <description>

--- a/features/edu.kit.ipd.sdq.metamodels.persons.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.metamodels.persons.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.metamodels.persons.feature"
       label="%featureName"
-      version="1.6.0"
+      version="1.7.0.qualifier"
       provider-name="%providerName" >
 
    <description>

--- a/features/edu.kit.ipd.sdq.metamodels.persons.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.metamodels.persons.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.metamodels.persons.feature"
       label="%featureName"
-      version="1.6.0.qualifier"
+      version="1.6.0"
       provider-name="%providerName" >
 
    <description>

--- a/features/edu.kit.ipd.sdq.metamodels.recipients.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.metamodels.recipients.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.metamodels.recipients.feature"
       label="%featureName"
-      version="1.6.0"
+      version="1.7.0.qualifier"
       provider-name="%providerName" >
 
    <description>

--- a/features/edu.kit.ipd.sdq.metamodels.recipients.feature/feature.xml
+++ b/features/edu.kit.ipd.sdq.metamodels.recipients.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="edu.kit.ipd.sdq.metamodels.recipients.feature"
       label="%featureName"
-      version="1.6.0.qualifier"
+      version="1.6.0"
       provider-name="%providerName" >
 
    <description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>1.6.0</version>
 		<relativePath>releng/edu.kit.ipd.sdq.metamodels.demo.parent</relativePath>
 	</parent>
 	<artifactId>edu.kit.ipd.sdq.metamodels.demo.main</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.6.0</version>
+		<version>1.7.0-SNAPSHOT</version>
 		<relativePath>releng/edu.kit.ipd.sdq.metamodels.demo.parent</relativePath>
 	</parent>
 	<artifactId>edu.kit.ipd.sdq.metamodels.demo.main</artifactId>

--- a/releng/edu.kit.ipd.sdq.metamodels.demo.aggregator/pom.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.demo.aggregator/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.6.0</version>
+		<version>1.7.0-SNAPSHOT</version>
 		<relativePath>../edu.kit.ipd.sdq.metamodels.demo.parent</relativePath>
 	</parent>
 	<artifactId>edu.kit.ipd.sdq.metamodels.demo.aggregator</artifactId>

--- a/releng/edu.kit.ipd.sdq.metamodels.demo.aggregator/pom.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.demo.aggregator/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>1.6.0</version>
 		<relativePath>../edu.kit.ipd.sdq.metamodels.demo.parent</relativePath>
 	</parent>
 	<artifactId>edu.kit.ipd.sdq.metamodels.demo.aggregator</artifactId>

--- a/releng/edu.kit.ipd.sdq.metamodels.demo.parent/pom.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.demo.parent/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.kit.ipd.sdq</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.6.0</version>
+	<version>1.7.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/releng/edu.kit.ipd.sdq.metamodels.demo.parent/pom.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.demo.parent/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.kit.ipd.sdq</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.6.0-SNAPSHOT</version>
+	<version>1.6.0</version>
 	<packaging>pom</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/releng/edu.kit.ipd.sdq.metamodels.demo.updatesite/category.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.demo.updatesite/category.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/edu.kit.ipd.sdq.metamodels.addresses.feature_1.6.0.jar" id="edu.kit.ipd.sdq.metamodels.addresses.feature" version="1.6.0">
+   <feature url="features/edu.kit.ipd.sdq.metamodels.addresses.feature_1.7.0.qualifier.jar" id="edu.kit.ipd.sdq.metamodels.addresses.feature" version="1.7.0.qualifier">
       <category name="demometamodels"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.metamodels.addresses.feature.source" version="1.6.0">
+   <feature id="edu.kit.ipd.sdq.metamodels.addresses.feature.source" version="1.7.0.qualifier">
       <category name="demometamodels"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.metamodels.recipients.feature_1.6.0.jar" id="edu.kit.ipd.sdq.metamodels.recipients.feature" version="1.6.0">
+   <feature url="features/edu.kit.ipd.sdq.metamodels.recipients.feature_1.7.0.qualifier.jar" id="edu.kit.ipd.sdq.metamodels.recipients.feature" version="1.7.0.qualifier">
       <category name="demometamodels"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.metamodels.recipients.feature.source" version="1.6.0">
+   <feature id="edu.kit.ipd.sdq.metamodels.recipients.feature.source" version="1.7.0.qualifier">
       <category name="demometamodels"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.metamodels.families.feature_1.6.0.jar" id="edu.kit.ipd.sdq.metamodels.families.feature" version="1.6.0">
+   <feature url="features/edu.kit.ipd.sdq.metamodels.families.feature_1.7.0.qualifier.jar" id="edu.kit.ipd.sdq.metamodels.families.feature" version="1.7.0.qualifier">
       <category name="demometamodels"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.metamodels.families.feature.source" version="1.6.0">
+   <feature id="edu.kit.ipd.sdq.metamodels.families.feature.source" version="1.7.0.qualifier">
       <category name="demometamodels"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.metamodels.persons.feature_1.6.0.jar" id="edu.kit.ipd.sdq.metamodels.persons.feature" version="1.6.0">
+   <feature url="features/edu.kit.ipd.sdq.metamodels.persons.feature_1.7.0.qualifier.jar" id="edu.kit.ipd.sdq.metamodels.persons.feature" version="1.7.0.qualifier">
       <category name="demometamodels"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.metamodels.persons.feature.source" version="1.6.0">
+   <feature id="edu.kit.ipd.sdq.metamodels.persons.feature.source" version="1.7.0.qualifier">
       <category name="demometamodels"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.metamodels.insurance.feature_1.6.0.jar" id="edu.kit.ipd.sdq.metamodels.insurance.feature" version="1.6.0">
+   <feature url="features/edu.kit.ipd.sdq.metamodels.insurance.feature_1.7.0.qualifier.jar" id="edu.kit.ipd.sdq.metamodels.insurance.feature" version="1.7.0.qualifier">
       <category name="demometamodels"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.metamodels.insurance.feature.source" version="1.6.0">
+   <feature id="edu.kit.ipd.sdq.metamodels.insurance.feature.source" version="1.7.0.qualifier">
       <category name="demometamodels"/>
    </feature>
    <category-def name="demometamodels" label="Demo Metamodels">

--- a/releng/edu.kit.ipd.sdq.metamodels.demo.updatesite/category.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.demo.updatesite/category.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/edu.kit.ipd.sdq.metamodels.addresses.feature_1.6.0.qualifier.jar" id="edu.kit.ipd.sdq.metamodels.addresses.feature" version="1.6.0.qualifier">
+   <feature url="features/edu.kit.ipd.sdq.metamodels.addresses.feature_1.6.0.jar" id="edu.kit.ipd.sdq.metamodels.addresses.feature" version="1.6.0">
       <category name="demometamodels"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.metamodels.addresses.feature.source" version="1.6.0.qualifier">
+   <feature id="edu.kit.ipd.sdq.metamodels.addresses.feature.source" version="1.6.0">
       <category name="demometamodels"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.metamodels.recipients.feature_1.6.0.qualifier.jar" id="edu.kit.ipd.sdq.metamodels.recipients.feature" version="1.6.0.qualifier">
+   <feature url="features/edu.kit.ipd.sdq.metamodels.recipients.feature_1.6.0.jar" id="edu.kit.ipd.sdq.metamodels.recipients.feature" version="1.6.0">
       <category name="demometamodels"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.metamodels.recipients.feature.source" version="1.6.0.qualifier">
+   <feature id="edu.kit.ipd.sdq.metamodels.recipients.feature.source" version="1.6.0">
       <category name="demometamodels"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.metamodels.families.feature_1.6.0.qualifier.jar" id="edu.kit.ipd.sdq.metamodels.families.feature" version="1.6.0.qualifier">
+   <feature url="features/edu.kit.ipd.sdq.metamodels.families.feature_1.6.0.jar" id="edu.kit.ipd.sdq.metamodels.families.feature" version="1.6.0">
       <category name="demometamodels"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.metamodels.families.feature.source" version="1.6.0.qualifier">
+   <feature id="edu.kit.ipd.sdq.metamodels.families.feature.source" version="1.6.0">
       <category name="demometamodels"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.metamodels.persons.feature_1.6.0.qualifier.jar" id="edu.kit.ipd.sdq.metamodels.persons.feature" version="1.6.0.qualifier">
+   <feature url="features/edu.kit.ipd.sdq.metamodels.persons.feature_1.6.0.jar" id="edu.kit.ipd.sdq.metamodels.persons.feature" version="1.6.0">
       <category name="demometamodels"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.metamodels.persons.feature.source" version="1.6.0.qualifier">
+   <feature id="edu.kit.ipd.sdq.metamodels.persons.feature.source" version="1.6.0">
       <category name="demometamodels"/>
    </feature>
-   <feature url="features/edu.kit.ipd.sdq.metamodels.insurance.feature_1.6.0.qualifier.jar" id="edu.kit.ipd.sdq.metamodels.insurance.feature" version="1.6.0.qualifier">
+   <feature url="features/edu.kit.ipd.sdq.metamodels.insurance.feature_1.6.0.jar" id="edu.kit.ipd.sdq.metamodels.insurance.feature" version="1.6.0">
       <category name="demometamodels"/>
    </feature>
-   <feature id="edu.kit.ipd.sdq.metamodels.insurance.feature.source" version="1.6.0.qualifier">
+   <feature id="edu.kit.ipd.sdq.metamodels.insurance.feature.source" version="1.6.0">
       <category name="demometamodels"/>
    </feature>
    <category-def name="demometamodels" label="Demo Metamodels">

--- a/releng/edu.kit.ipd.sdq.metamodels.demo.updatesite/pom.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.demo.updatesite/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>1.6.0</version>
 		<relativePath>../edu.kit.ipd.sdq.metamodels.demo.parent</relativePath>
 	</parent>
 	<artifactId>edu.kit.ipd.sdq.metamodels.demo.updatesite</artifactId>

--- a/releng/edu.kit.ipd.sdq.metamodels.demo.updatesite/pom.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.demo.updatesite/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.6.0</version>
+		<version>1.7.0-SNAPSHOT</version>
 		<relativePath>../edu.kit.ipd.sdq.metamodels.demo.parent</relativePath>
 	</parent>
 	<artifactId>edu.kit.ipd.sdq.metamodels.demo.updatesite</artifactId>

--- a/releng/edu.kit.ipd.sdq.metamodels.workflow/META-INF/MANIFEST.MF
+++ b/releng/edu.kit.ipd.sdq.metamodels.workflow/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Demo Metamodels Workflow
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.workflow
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.0
 Bundle-Vendor: KIT SDQ
 Automatic-Module-Name: edu.kit.ipd.sdq.metamodels.workflow
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/releng/edu.kit.ipd.sdq.metamodels.workflow/META-INF/MANIFEST.MF
+++ b/releng/edu.kit.ipd.sdq.metamodels.workflow/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Demo Metamodels Workflow
 Bundle-SymbolicName: edu.kit.ipd.sdq.metamodels.workflow
-Bundle-Version: 1.6.0
+Bundle-Version: 1.7.0.qualifier
 Bundle-Vendor: KIT SDQ
 Automatic-Module-Name: edu.kit.ipd.sdq.metamodels.workflow
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/releng/edu.kit.ipd.sdq.metamodels.workflow/pom.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.workflow/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.6.0</version>
+		<version>1.7.0-SNAPSHOT</version>
 		<relativePath>../edu.kit.ipd.sdq.metamodels.demo.parent</relativePath>
 	</parent>
 	<artifactId>edu.kit.ipd.sdq.metamodels.workflow</artifactId>

--- a/releng/edu.kit.ipd.sdq.metamodels.workflow/pom.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.workflow/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>edu.kit.ipd.sdq</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>1.6.0</version>
 		<relativePath>../edu.kit.ipd.sdq.metamodels.demo.parent</relativePath>
 	</parent>
 	<artifactId>edu.kit.ipd.sdq.metamodels.workflow</artifactId>


### PR DESCRIPTION
Thi PR releases version 1.6.0 containing the following changes:
* Addition of utilities for families, persons and insurance metamodels, which were previously defined in the [Vitruv project](vitruv.tools).