### PR TITLE
Compile Xtend code in Maven build

### DIFF
--- a/releng/edu.kit.ipd.sdq.metamodels.demo.parent/pom.xml
+++ b/releng/edu.kit.ipd.sdq.metamodels.demo.parent/pom.xml
@@ -9,6 +9,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven-clean.version>3.1.0</maven-clean.version>
 		<tycho.version>2.5.0</tycho.version>
 		<mwe.version>1.6.1</mwe.version>
 		<mwe2.version>2.12.1</mwe2.version>
@@ -47,6 +48,47 @@
 				<configuration>
 					<useProjectSettings>false</useProjectSettings>
 				</configuration>
+			</plugin>
+
+			<!-- Use Xtend -->
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+				<version>${xtext.version}</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>xtend-gen</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Consider Xtend in cleanup -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>${maven-clean.version}</version>
+				<executions>
+					<execution>
+						<id>gen-clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+						<configuration>
+							<filesets>
+								<fileset>
+									<directory>xtend-gen</directory>
+								</fileset>
+							</filesets>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
By accident, #17 did not enable Xtend code compilation in the Maven build for the newly added classes specified in Xtend. This PR fixes the build.